### PR TITLE
Integrate better vpcmidonet with firewalld

### DIFF
--- a/roles/ceph-common/defaults/main.yml
+++ b/roles/ceph-common/defaults/main.yml
@@ -36,7 +36,7 @@ cloud_firewalld_cluster_interface: "{{ eucalyptus_host_cluster_interface if euca
 
 cloud_firewalld_cluster_zone: internal
 
-cloud_firewalld_default_zone: trusted
+cloud_firewalld_default_zone: public
 
 cloud_firewalld_start: yes
 

--- a/roles/cloud/tasks/vpcmido.yml
+++ b/roles/cloud/tasks/vpcmido.yml
@@ -192,6 +192,32 @@
   changed_when: '"NAME_CONFLICT" not in firewalld_result.stderr'
   when: cloud_firewalld_configure
 
+- name: eucalyptus firewalld midonet gateway zone services
+  firewalld:
+    zone: euca-vpcmidogw
+    service: "euca-vpcmidogw-{{ cidr_index }}"
+    state: enabled
+    permanent: yes
+    immediate: "{{ cloud_firewalld_start }}"
+  loop: "{{ vpcmido_public_ip_cidrs }}"
+  loop_control:
+    index_var: cidr_index
+    loop_var: cidr
+  tags:
+    - firewalld
+  when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none
+
+- name: eucalyptus firewalld midonet gw device to trusted zone
+  firewalld:
+    zone: trusted
+    interface: "{{ vpcmido_gw_srv_veth0 }}"
+    state: enabled
+    permanent: yes
+    immediate: "{{ cloud_firewalld_start }}"
+  tags:
+    - firewalld
+  when: cloud_firewalld_configure
+
 - name: firewalld reload
   systemd:
     name: firewalld
@@ -200,20 +226,20 @@
     - firewalld
   when: cloud_firewalld_configure and firewalld_result.changed
 
-#- name: eucalyptus firewalld midonet gateway services for zone
-#  firewalld:
-#    zone: "{{ cloud_firewalld_vpcmidogw_zone }}"
-#    service: "euca-vpcmidogw-{{ cidr_index }}"
-#    state: enabled
-#    permanent: yes
-#    immediate: "{{ cloud_firewalld_start }}"
-#  loop: "{{ vpcmido_public_ip_cidrs }}"
-#  loop_control:
-#    index_var: cidr_index
-#    loop_var: cidr
-#  tags:
-#    - firewalld
-#  when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none
+- name: eucalyptus firewalld midonet gateway services for zone
+  firewalld:
+    zone: "{{ cloud_firewalld_vpcmidogw_zone }}"
+    service: "euca-vpcmidogw-{{ cidr_index }}"
+    state: enabled
+    permanent: yes
+    immediate: "{{ cloud_firewalld_start }}"
+  loop: "{{ vpcmido_public_ip_cidrs }}"
+  loop_control:
+    index_var: cidr_index
+    loop_var: cidr
+  tags:
+    - firewalld
+  when: cloud_firewalld_configure and cloud_firewalld_vpcmidogw_zone is not none
 
 - name: eucalyptus firewalld midonet gateway dedicated interface zone
   firewalld:

--- a/roles/cloud/templates/firewalld-zone-euca-vpcmidogw.xml.j2
+++ b/roles/cloud/templates/firewalld-zone-euca-vpcmidogw.xml.j2
@@ -2,5 +2,4 @@
 <zone>
   <short>Eucalyptus Cloud Midonet Gateway Zone</short>
   <description>Zone for Eucalyptus midonet gateway traffic</description>
-  <service name="euca-vpcmidogw"/>
 </zone>

--- a/roles/none/tasks/main.yml
+++ b/roles/none/tasks/main.yml
@@ -310,6 +310,37 @@
   - "minio"
   - "minio-key"
 
+- name: find the sysctl added files
+  find:
+    paths: /etc/sysctl.d/
+    file_type: file
+    patterns: '80-net-*.conf'
+    use_regex: true
+  register: netfiles
+
+- name: remove the sysctl added rules
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items: "{{ netfiles.files }}"
+
+- name: remove added firewalld services and zones
+  file:
+    path: "{{ item }}"
+  loop:
+  - "/etc/firewalld/zone/euca-cluster.xml"
+  - "/etc/firewalld/zone/euca-vpcmidogw.xml"
+  - "/etc/firewalld/services/euca-gre.xml"
+  - "/etc/firewalld/services/eucalyptus.xml"
+  - "/etc/firewalld/services/eucalyptus.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-0.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-1.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-2.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-3.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-4.xml"
+  - "/etc/firewalld/services/euca-vpcmidogw-5.xml"
+
 - name: remove minio application directory
   file:
     path: /opt/minio


### PR DESCRIPTION
Few changes to integrate better with firewall: in particular making sure
that the default zone is public (to ensure stray interface won't be put
in trusted accidentally), handle multiple cidr to define public IP
address, put the midonet interface into trusted zone, and clean up all
the extra created files when cleaning up the deployment.