### PR TITLE
Option to be compatible with newer awscli

### DIFF
--- a/roles/cloud-post/tasks/main.yml
+++ b/roles/cloud-post/tasks/main.yml
@@ -63,6 +63,13 @@
     name: dnsdist@eucalyptus
   when: cloud_dns_authoritative_balancer|default(False)
 
+- name: compatibility with latest awscli versions
+  shell: |
+    set -eu
+    eval $(clcadmin-assume-system-credentials)
+    euctl bootstrap.webservices.unknown_parameter_handling=ignore
+  when: cloud_awscli_compatibility
+
 - name: add T3 instances type
   shell: |
     set -eu

--- a/roles/cloud/defaults/main.yml
+++ b/roles/cloud/defaults/main.yml
@@ -15,6 +15,7 @@ cloud_container_image_size: "2"
 cloud_initial_accounts_default: [ "aws", "amazon", "euca" ]
 cloud_initial_accounts_custom: []
 cloud_initial_accounts: "{{ cloud_initial_accounts_default + cloud_initial_accounts_custom }}"
+cloud_awscli_compatibility: no
 
 # EDGE network settings
 edge_subnet: "{{ '172.31.0.0' if edge_bridge_create else ansible_default_ipv4.network }}"


### PR DESCRIPTION
This option instructs the CLC to ignore flags that are unknown: this
would help to use newer AWSCLI.