### PR TITLE
Added ceph service to open port for ceph cluster

### DIFF
--- a/roles/ceph-common/files/firewalld-service-ceph.xml
+++ b/roles/ceph-common/files/firewalld-service-ceph.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Ceph Zone</short>
+  <description>Ports needed for a ceph network</description>
+  <port protocol="tcp" port="3300"/>
+  <port protocol="tcp" port="6789"/>
+  <port protocol="udp" port="6800-7300"/>
+  <port protocol="tcp" port="7480"/>
+</service>

--- a/roles/ceph-common/tasks/base_firewall.yml
+++ b/roles/ceph-common/tasks/base_firewall.yml
@@ -29,6 +29,36 @@
     - firewalld
   when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
 
+- name: firewalld ceph service
+  copy:
+    src: firewalld-service-ceph.xml
+    dest: /etc/firewalld/services/ceph.xml
+    owner: root
+    group: root
+    mode: 0644
+  tags:
+    - firewalld
+  when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
+
+- name: firewalld reload
+  systemd:
+    name: firewalld
+    state: reloaded
+  tags:
+    - firewalld
+  when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
+
+- name: add ceph service if needed
+  firewalld:
+    zone: "{{ cloud_firewalld_cluster_zone }}"
+    service: ceph
+    state: enabled
+    permanent: yes
+    immediate: "{{ cloud_firewalld_start }}"
+  tags:
+    - firewalld
+  when: cloud_firewalld_cluster_interface is not none and cloud_firewalld_cluster_zone is not none
+
 - name: eucalyptus gre service
   copy:
     src: firewalld-service-euca-gre.xml


### PR DESCRIPTION
This is to ensure that if ceph cluster is working on its own
interface/network, firewalld will have the port opened to let ceph
operate.